### PR TITLE
[EditTK] Implemented VeldridSDLWindow.CustomFlags

### DIFF
--- a/EditTK.Testing/EditTK.Testing/Program.cs
+++ b/EditTK.Testing/EditTK.Testing/Program.cs
@@ -51,24 +51,21 @@ namespace EditTK.Testing
 
             WindowManager.SetDefaultFont(SystemUtils.RelativeFilePath("Resources", "Font.ttf"), 14);
 
-
             {
-                WindowCreateInfo windowCI = new()
-                {
+                WindowCreateInfo windowCI = new() {
                     X = 100,
                     Y = 100,
-                    WindowWidth = (int)(960 * Dpi),
-                    WindowHeight = (int)(540 * Dpi),
+                    WindowWidth = (int) (960 * Dpi),
+                    WindowHeight = (int) (540 * Dpi),
                     WindowTitle = "EditTK Playground"
                 };
 
                 var w = new TestWindow(windowCI);
 
+                w.CustomFlags = SDL_WindowFlags.Borderless;
+
                 w.Run();
             }
-
-
-            //w.Run();
         }
     }
 }

--- a/EditTK.Testing/EditTK.Testing/Program.cs
+++ b/EditTK.Testing/EditTK.Testing/Program.cs
@@ -62,7 +62,7 @@ namespace EditTK.Testing
 
                 var w = new TestWindow(windowCI);
 
-                w.CustomFlags = SDL_WindowFlags.Borderless;
+                //w.CustomFlags = SDL_WindowFlags.Borderless;
 
                 w.Run();
             }

--- a/EditTK/Windowing/VeldridSDLWindow.cs
+++ b/EditTK/Windowing/VeldridSDLWindow.cs
@@ -94,6 +94,8 @@ namespace EditTK.Windowing
 
         public bool Hovered { get; private set; }
 
+        public SDL_WindowFlags CustomFlags { set; private get; }
+
         public VeldridSDLWindow(WindowCreateInfo wci)
         {
             _wci = wci;
@@ -108,7 +110,7 @@ namespace EditTK.Windowing
             _window?.Close();
 
             SDL_WindowFlags flags = SDL_WindowFlags.OpenGL | SDL_WindowFlags.Resizable
-                    | GetWindowFlags(_wci.WindowInitialState);
+                    | GetWindowFlags(_wci.WindowInitialState) | CustomFlags;
             if (_wci.WindowInitialState != WindowState.Hidden)
             {
                 flags |= SDL_WindowFlags.Shown;


### PR DESCRIPTION
The objective of this commit is to enable the user to change flags from the window like AlwaysOnTop or Borderless before using Run().